### PR TITLE
Add a way to show `long description` on `servo-experiment`

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -5,25 +5,25 @@
             "name": "DIVMosaics",
             "desc": "<p>Mosaic effect using DIV's</p>",
             "href": "experiments/divMosaics/",
-            "long_description":"Displays images in a mosaic effect using multiple DIV's as the mosaic tiles.  Each mosaic tile is animated using transtions on the top and left properties.</p><p>The mosaic effect shows Servo's ability to deal with many DOM elements aswell as their transitions.  The transitions in particular perform very well in Servo thanks to the hardware acceleration provided by Servo's rendering engine, WebRender.</p>"
+            "long_description":"<p>In this experiment each mosaic tile is animated using transtions on the top and left properties.</p><p>The mosaic effect shows Servo's ability to deal with many DOM elements aswell as their transitions.  The transitions in particular perform very well in Servo thanks to the hardware acceleration provided by Servo's rendering engine, WebRender.</p>"
         },
         {
             "name": "Mosaic Gallery",
             "desc": "<p>A gallery of generated DIV mosaics.  ",
             "href": "experiments/tiles/",
-            "long_description":"<p>A gallery of generated DIV mosaics.  Here, the DIV tiles representing each pixel are positioned statically and have transitions on their background colour property.</p>"
+            "long_description":"<p>This experiment features a gallery of generated DIV mosaics, where each pixel is represented by a static position and has transitions on their background color property. </p><p>On the page, the mosaic gallery is created by dividing the image into smaller units (pixels) represented by individual DIV elements. Each DIV element is positioned statically to form a mosaic-like grid.</p>"
         },
         {
             "name": "DIV Rain",
             "desc": "<p>Animated rain effect using DIVs.</p>",
             "href": "experiments/swirly/",
-            "long_description":""
+            "long_description":"<p>This experiment demonstrates an animated rain effect using HTML div elements. This experiment specifically focuses on testing the rendering and animation capabilities of Servo by creating a rain effect using CSS and HTML. </p><p> It provides a visually interactive demonstration of how Servo handles complex animations and effects in a web browser context.</p>"
         },
         {
             "name": "DIV Waves",
             "desc": "<p>Animated wave effect using DIVs.</p>",
             "href": "experiments/divWaves/",
-            "long_description":""
+            "long_description":"This experiment specifically focuses on testing the rendering and animation capabilities of Servo by creating a visually dynamic and colorful wave effect. The wave animation is achieved by manipulating the position, size, and color of the HTML <div> elements. </p><p> This experiment helps evaluating and showcasing its ability to handle and render complex visual effects in a performant manner."
         }
     ],
     "tests": [
@@ -31,7 +31,7 @@
             "name": "Dogemania Benchmark",
             "desc": "<p>Benchmark your browser with Doges.</p>",
             "href": "experiments/dogemania/",
-            "long_description":""
+            "long_description":"This experiment provides a visual representation of the browser's activity through the servo-logo image and measures the performance using the FPS count."
         }
     ]
 

--- a/experiments.json
+++ b/experiments.json
@@ -5,7 +5,7 @@
             "name": "DIVMosaics",
             "desc": "<p>Mosaic effect using DIV's</p>",
             "href": "experiments/divMosaics/",
-            "long_description":"<p>Displays images in a mosaic effect using multiple DIV's as the mosaic tiles.  Each mosaic tile is animated using transtions on the top and left properties.</p><p>The mosaic effect shows Servo's ability to deal with many DOM elements aswell as their transitions.  The transitions in particular perform very well in Servo thanks to the hardware acceleration provided by Servo's rendering engine, WebRender.</p>"
+            "long_description":"Displays images in a mosaic effect using multiple DIV's as the mosaic tiles.  Each mosaic tile is animated using transtions on the top and left properties.</p><p>The mosaic effect shows Servo's ability to deal with many DOM elements aswell as their transitions.  The transitions in particular perform very well in Servo thanks to the hardware acceleration provided by Servo's rendering engine, WebRender.</p>"
         },
         {
             "name": "Mosaic Gallery",

--- a/experiments.json
+++ b/experiments.json
@@ -31,7 +31,7 @@
             "name": "Dogemania Benchmark",
             "desc": "<p>Benchmark your browser with Doges.</p>",
             "href": "experiments/dogemania/",
-            "long_description":"This experiment provides a visual representation of the browser's activity through the servo-logo image and measures the performance using the FPS count."
+            "long_description":"<p>This experiment provides a visual representation of the browser's activity through the servo-logo image and measures the performance using the FPS count.</p>You can benchmark your browser with servo-doges <p></p>"
         }
     ]
 

--- a/index.html
+++ b/index.html
@@ -23,11 +23,11 @@
             </header>
             <main class="experiments-container">
                 <section class="experiments-group" id="other-experiments">
-                    <h3 class="heading">Servo Experiments</h3>
+                    <h3 class="heading">Servo Experiments (<a href="https://github.com/servo/servo-experiments" target="_blank">Contribute</a>) </h3>
                     <div class="experiment-previews"></div>
                 </section>
                 <section class="experiments-group" id="technical-tests">
-                    <h3 class="heading">Servo Technical Tests</h3>
+                    <h3 class="heading">Servo Technical Tests (<a href="https://github.com/servo/servo-experiments" target="_blank">Contribute</a>) </h3>
                     <div class="experiment-previews"></div>
                 </section>
             </main>

--- a/js/index.js
+++ b/js/index.js
@@ -62,31 +62,31 @@ window.addEventListener('load', function () {
                 let desc = document.createElement('div')
                 desc.classList.add('experiment-desc')
 
-                let originalDesc = document.createElement('div')
-                originalDesc.innerHTML = info.desc
-                desc.appendChild(originalDesc)
+                let short_description = document.createElement('div')
+                short_description.innerHTML = info.desc
+                desc.appendChild(short_description)
 
                 let long_description = document.createElement('div')
                 long_description.innerHTML = info.long_description
                 long_description.style.display = 'none'
                 desc.appendChild(long_description)
 
-                let toggleButton = document.createElement('a');
-                toggleButton.textContent = 'Read More';
-                toggleButton.classList.add('toggle-button');
-                toggleButton.style.display = 'block';
-                toggleButton.style.marginTop = '10px';
-                toggleButton.style.color = 'blue';
-                toggleButton.style.cursor = 'pointer';
-                desc.appendChild(toggleButton);
+                let toggle = document.createElement('a');
+                toggle.textContent = 'Read More';
+                toggle.classList.add('toggle-button');
+                toggle.style.display = 'block';
+                toggle.style.marginTop = '10px';
+                toggle.style.color = 'blue';
+                toggle.style.cursor = 'pointer';
+                desc.appendChild(toggle);
 
-                toggleButton.addEventListener('click', function () {
+                toggle.addEventListener('click', function () {
                   if (long_description.style.display === 'none') {
                     long_description.style.display = 'block';
-                    toggleButton.textContent = 'Read Less';
+                    toggle.textContent = 'Read Less';
                   } else {
                     long_description.style.display = 'none';
-                    toggleButton.textContent = 'Read More';
+                    toggle.textContent = 'Read More';
                   }
                 });
           

--- a/js/index.js
+++ b/js/index.js
@@ -1,7 +1,7 @@
 function Http() {}
 
 Http.get = function (url, cb) {
-    var req = new XMLHttpRequest()
+    let req = new XMLHttpRequest()
     req.responseType = 'json'
     req.addEventListener('load', function (evt) {
         cb(req.response)
@@ -24,31 +24,31 @@ window.addEventListener('load', function () {
         )
     })
 
-    var tagWrap = function (tagName, el) {
-        var tagEl = document.createElement(tagName)
+    let tagWrap = function (tagName, el) {
+        let tagEl = document.createElement(tagName)
         tagEl.appendChild(el)
         return tagEl
     }
 
-    var hrefWrap = function (el, href) {
-        var a = tagWrap('a', el)
+    let hrefWrap = function (el, href) {
+        let a = tagWrap('a', el)
         a.href = href
         return a
     }
 
-    var pWrap = tagWrap.bind(null, 'p')
-    var experimentsPerRow = 3
+    let pWrap = tagWrap.bind(null, 'p')
+    let experimentsPerRow = 3
 
     function addExperiments(ul, experiments, showDesc) {
-        var lis = experiments.map(function (info, i) {
-            var article = document.createElement('article')
+        let lis = experiments.map(function (info, i) {
+            let article = document.createElement('article')
             article.classList.add('experiment-preview')
 
-            var h2 = document.createElement('h2')
+            let h2 = document.createElement('h2')
             h2.textContent = info.name
             article.appendChild(hrefWrap(h2, info.href))
 
-            var screen = document.createElement('img')
+            let screen = document.createElement('img')
             screen.src = info.href + 'thumb.png'
             screen.width = 256
             screen.height = 256
@@ -59,16 +59,38 @@ window.addEventListener('load', function () {
             }
 
             if (showDesc) {
-                var desc = document.createElement('div')
+                let desc = document.createElement('div')
                 desc.classList.add('experiment-desc')
-                if (info.desc.indexOf('<p>') === -1) {
-                    // No p tag detected, insert one.
-                    desc.appendChild(pWrap(document.createTextNode(info.desc)))
-                } else {
-                    // Otherwise just use HTML provided.
-                    desc.innerHTML = info.desc
-                }
-                article.appendChild(hrefWrap(desc, info.href))
+
+                let originalDesc = document.createElement('div')
+                originalDesc.innerHTML = info.desc
+                desc.appendChild(originalDesc)
+
+                let long_description = document.createElement('div')
+                long_description.innerHTML = info.long_description
+                long_description.style.display = 'none'
+                desc.appendChild(long_description)
+
+                let toggleButton = document.createElement('a');
+                toggleButton.textContent = 'Read More';
+                toggleButton.classList.add('toggle-button');
+                toggleButton.style.display = 'block';
+                toggleButton.style.marginTop = '10px';
+                toggleButton.style.color = 'blue';
+                toggleButton.style.cursor = 'pointer';
+                desc.appendChild(toggleButton);
+
+                toggleButton.addEventListener('click', function () {
+                  if (long_description.style.display === 'none') {
+                    long_description.style.display = 'block';
+                    toggleButton.textContent = 'Read Less';
+                  } else {
+                    long_description.style.display = 'none';
+                    toggleButton.textContent = 'Read More';
+                  }
+                });
+          
+                article.appendChild(desc);
             }
 
             return article


### PR DESCRIPTION
- Added a way to show `long description` for each experiment on landing page
- Added contribute link on servo-experiment page
- some small cleanups
<img width="1499" alt="image" src="https://github.com/servo/servo-experiments/assets/94557773/c37de39a-3694-4e07-b043-0ad4e330e5b7">


<img width="1509" alt="image" src="https://github.com/servo/servo-experiments/assets/94557773/d33341a3-916f-4aec-9e81-08e2d7c0848f">
