### PR TITLE
Add CW in description of twgl experiment

### DIFF
--- a/experiments.json
+++ b/experiments.json
@@ -34,7 +34,7 @@
         },
         {
             "name": "TWGL Tunnel",
-            "desc": "<p>Tunnel effect using WebGL and the TWGL library.</p>",
+            "desc": "<p>Tunnel effect(TWGL). ⚠️  Trippy visuals, potential epilepsy triggers.</p>",
             "href": "experiments/twgl-tunnel/",
             "long_description": "<p>This experiment demonstrates the WebGL capabilities of servo. The tunnel effect is created by manipulating vertices and applying transformations to create the illusion of depth and movement. </p><p> The demo serves as a demonstration of WebGL capabilities and showcases dynamic and interactive 3D graphics using TWGL</p>"
         }


### PR DESCRIPTION
As reported in #11  Adding an CW in the description of TWGL tunnel effect experiment

<img width="336" alt="image" src="https://github.com/servo/servo-experiments/assets/94557773/4c8a5b28-9364-4965-831c-37a76d59b410">
