### PR TITLE
Avoid console error removing unused code

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -105,10 +105,4 @@ window.addEventListener('load', function () {
         })
     }
 
-    requestAnimationFrame(animate)
-    function animate(t) {
-        requestAnimationFrame(animate)
-
-        TWEEN.update(t)
-    }
 })


### PR DESCRIPTION
This avoids the following console error:
  Error at https://demo.servo.org/js/index.js:112:9 TWEEN is not defined