### PR TITLE
add link to experiments

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,8 @@
                         src="images/servo-color-positive.png" />
                 </a>
                 <div class="nav-right">
-                    <a href="https://servo.org/contributing" target="_blank">Contribute</a>
-                    <a href="https://github.com/servo/servo/wiki" target="_blank">Wiki</a>
-                    <a href="https://github.com/servo/servo" target="_blank">Github</a>
+                    <a href="https://github.com/servo/servo-experiments/blob/gh-pages/README.md" target="_blank">Add Demo</a>
+                    <a href="https://github.com/servo/servo/wiki" target="_blank">Servo Wiki</a>
                 </div>
             </div>
             <hr />


### PR DESCRIPTION
In #20 I added the link to servo in `Contribute`, We should have link to `servo-experiments` instead.