### PR TITLE
Add 1% low fps tracker to physics-particles experiment

### DIFF
--- a/experiments/physicsParticles/js/lib.js
+++ b/experiments/physicsParticles/js/lib.js
@@ -14,6 +14,8 @@ function loop(callback) {
   var frames = 0;
   // The sum of all frames per second.
   var fpsSum = 0;
+  // Histogram of fps
+  var fpsHisto = [];
   var prevT = now();
 
   function tick() {
@@ -23,7 +25,24 @@ function loop(callback) {
     avgFps = smooth(avgFps, fps, 0.03);
     frames = frames + 1;
     var avgFps = fpsSum / frames;
-    callback(frames, currT, prevT, Math.round(fps), Math.round(avgFps));
+    var roundFps = Math.round(fps);
+    if (fpsHisto[roundFps] == undefined) {
+      fpsHisto[roundFps]=0;
+    }
+    fpsHisto[roundFps] += 1;
+    var percentile = 0;
+    if (frames >= 100) {
+      var i = 0;
+      var prefixSum = 0;
+      while (prefixSum < frames / 100) {
+        if (fpsHisto[i] != undefined) {
+          prefixSum += fpsHisto[i];
+        }
+        i += 1;
+      }
+      percentile = i;
+    }
+    callback(frames, currT, prevT, Math.round(fps), Math.round(avgFps), percentile);
     prevT = currT;
     if (next) requestAnimationFrame(tick);
   };

--- a/experiments/physicsParticles/physics.js
+++ b/experiments/physicsParticles/physics.js
@@ -103,7 +103,7 @@ on(containerEl, 'mouseup', function (event) {
   mouseRepulsion.setRadius(100 * RADIUS_SCALE);
 });
 
-loop(function (frames, currFrameT, prevFrameT, fps, averageFPS) {
+loop(function (frames, currFrameT, prevFrameT, fps, averageFPS, firstPercent) {
   // Skip every other frame and let CSS transitions do the tweening.
   if (frames % FRAMESKIP == 0) {
     // Advance physics simulation.
@@ -121,5 +121,5 @@ loop(function (frames, currFrameT, prevFrameT, fps, averageFPS) {
 
   // Calc delta between last and current frame start
   // + delta between frame start and frame end.
-  text(fpsEl, 'AVG FPS: ' + averageFPS + ' FPS: ' + fps);
+  text(fpsEl, '1% LOW: ' + firstPercent + ' AVG FPS: ' + averageFPS + ' FPS: ' + fps);
 });


### PR DESCRIPTION
I noticed that the physics-particles demo is appreciably smoother with Servo than with Firefox on my laptop, despite them showing the same average fps. I added this first-percentile fps tracker to demonstrate the difference. I believe first-percentile fps is a standard metric for that sort of thing in computer graphics.